### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/llmmas_0621_US.ipynb
+++ b/llmmas_0621_US.ipynb
@@ -124,7 +124,7 @@
       "source": [
         "# --- Installation Python Package ---\n",
         "!pip install -q yfinance pandas numpy matplotlib stable-baselines3[extra] plotly pyfolio gym gymnasium scikit-learn tensorflow optuna tqdm markdown 'shimmy>=2.0'\n",
-        "!pip install -q beautifulsoup4 feedparser requests openai newsapi-python fredapi pytrends nltk crewai crewai[tools] autogen pyautogen python-dotenv anthropic google-generativeai\n",
+        "!pip install -q beautifulsoup4 feedparser requests openai newsapi-python fredapi pytrends nltk crewai crewai[tools] autogen ag2 python-dotenv anthropic google-generativeai\n",
         "!pip install --upgrade lxml # beautifulsoup (if used)\n",
         "!python -m nltk.downloader vader_lexicon # Download NLTK sentiment analysis resources (if used)"
       ]


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
